### PR TITLE
Fixed delay with some flash players in firefox (eg. Twitch.tv)

### DIFF
--- a/lightsOn.sh
+++ b/lightsOn.sh
@@ -109,9 +109,9 @@ checkFullscreen()
     for display in $displays
     do
         #get id of active window and clean output
-        activ_win_id=`DISPLAY=:0.${display} xprop -root _NET_ACTIVE_WINDOW`
+        activ_win_id=`DISPLAY=:0.${display} xprop -root _NET_CLIENT_LIST_STACKING` #previously used _NET_ACTIVE_WINDOW, but it didn't work with some flash players (eg. Twitch.tv) in firefox
         #activ_win_id=${activ_win_id#*# } #gives error if xprop returns extra ", 0x0" (happens on some distros)
-        activ_win_id=${activ_win_id:40:9}
+        activ_win_id=${activ_win_id:${#activ_win_id}-10:10}
 
         # Skip invalid window ids (commented as I could not reproduce a case
         # where invalid id was returned, plus if id invalid


### PR DESCRIPTION
These players didn't report as active while fullscreen.

Tested on Ubuntu 14.04 x64
