### PR TITLE
Fixed failing to delay on some systems and displaying unnecessarry error messages on others 

### DIFF
--- a/lightsOn.sh
+++ b/lightsOn.sh
@@ -364,7 +364,10 @@ delayScreensaver()
             log "delayScreensaver(): trying to delay with xdg-screensaver..."
             xdg-screensaver reset
         fi
-        xdotool key ctrl
+        if [ -f /usr/bin/xdotool ]; then
+            log "delayScreensaver(): trying to delay with xdotool..."
+            xdotool key ctrl
+        fi
     fi
 
     #Check if DPMS is on. If it is, deactivate. If it is not, do nothing.


### PR DESCRIPTION
Fixed not delaying because of varying window id lengths, and displaying error messages on some systems without xdotool.
Tested on Ubuntu 14.04 x64
